### PR TITLE
fix(deps): upgrade the Prost stack to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -420,7 +420,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4978,11 +4978,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap 2.11.4",
 ]
 
@@ -5418,9 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5428,16 +5429,15 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5448,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -5461,9 +5461,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.15.3"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
 dependencies = [
  "base64",
  "prost",
@@ -5475,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect-build"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8db7191445b1dbee19df4f6b6294e5123aef52620b344a630bb845d302622a"
+checksum = "95a9e8261adf6617d5dc2a5a9e75cce5ab9d546a007f6f870f809a1ad25386b6"
 dependencies = [
  "prost-build",
  "prost-reflect",
@@ -5485,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect-derive"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab076798900edeaf1499ed1c30097db86e6697c5d02660a63d72fe4ebdcfefd2"
+checksum = "30320eb03b43b7dfcaf9b361f808a4f1adad1e718ad219df1d7e4283e34e73f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5496,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]

--- a/crates/fig_proto/Cargo.toml
+++ b/crates/fig_proto/Cargo.toml
@@ -16,8 +16,8 @@ bytes.workspace = true
 fig_util.workspace = true
 flate2.workspace = true
 hex.workspace = true
-prost = "0.13.5"
-prost-reflect = { version = "0.15.2", features = ["serde", "derive"] }
+prost = "0.14.4"
+prost-reflect = { version = "0.16.5", features = ["serde", "derive"] }
 rand.workspace = true
 rmp-serde = "1.3.0"
 serde.workspace = true
@@ -29,6 +29,6 @@ uuid.workspace = true
 nix.workspace = true
 
 [build-dependencies]
-prost-build = "0.13.5"
-prost-reflect-build = "0.15.1"
+prost-build = "0.14.4"
+prost-reflect-build = "0.16.1"
 tempfile.workspace = true

--- a/crates/fig_proto/src/lib.rs
+++ b/crates/fig_proto/src/lib.rs
@@ -247,7 +247,7 @@ pub trait FigProtobufEncodable: Debug + Send + Sync {
     fn encode_fig_protobuf(&self) -> Result<Bytes, FigMessageEncodeError>;
 }
 
-impl<T: Message> FigProtobufEncodable for T {
+impl<T: Message + Debug> FigProtobufEncodable for T {
     fn encode_fig_protobuf(&self) -> Result<Bytes, FigMessageEncodeError> {
         FigMessage::encode(FigMessageType::Protobuf, self.encode_to_vec().into())
     }


### PR DESCRIPTION
## Summary

- upgrade `prost` and `prost-build` together to 0.14.4
- upgrade the matching `prost-reflect` packages
- add the explicit `Debug` bound required by Prost 0.14
- replace the incompatible partial updates in #27, #78, #83, and #114

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --workspace --color always -- -D warnings`
- `cargo test --locked --workspace`
- `cargo build --release --locked -p fig_desktop -p figterm -p ec_cli -p fig_input_method`