### PR TITLE
fix(deps): bump seven dependencies past their breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,19 +993,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
@@ -1414,15 +1401,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.15.11",
+ "console",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1492,7 +1478,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,13 +1639,13 @@ dependencies = [
  "parking_lot",
  "paste",
  "predicates",
- "rand 0.9.2",
+ "rand 0.10.2",
  "regex",
  "semver",
  "serde",
  "serde_json",
  "spinners",
- "sysinfo",
+ "sysinfo 0.36.1",
  "tempfile",
  "thiserror 2.0.19",
  "time",
@@ -1749,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1923,7 +1909,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.10.2",
  "regex",
  "reqwest",
  "rfd",
@@ -1931,7 +1917,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "sysinfo",
+ "sysinfo 0.36.1",
  "system-configuration",
  "tao",
  "tempfile",
@@ -2005,7 +1991,7 @@ dependencies = [
  "fig_util",
  "serde",
  "serde_json",
- "sysinfo",
+ "sysinfo 0.36.1",
  "time",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -2111,7 +2097,7 @@ dependencies = [
  "flate2",
  "nix 0.29.0",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.10.2",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -2143,7 +2129,7 @@ dependencies = [
  "dirs 5.0.1",
  "nix 0.29.0",
  "serde",
- "sysinfo",
+ "sysinfo 0.36.1",
  "tempfile",
  "tokio",
 ]
@@ -2162,7 +2148,7 @@ dependencies = [
  "prost-build",
  "prost-reflect",
  "prost-reflect-build",
- "rand 0.9.2",
+ "rand 0.10.2",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2273,13 +2259,13 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "paste",
- "rand 0.9.2",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "strum 0.28.0",
- "sysinfo",
+ "sysinfo 0.36.1",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -2335,7 +2321,7 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "shlex 2.0.1",
- "sysinfo",
+ "sysinfo 0.36.1",
  "tempfile",
  "time",
  "tokio",
@@ -3399,7 +3385,7 @@ version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.16.4",
+ "console",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -3450,7 +3436,7 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
- "console 0.16.4",
+ "console",
  "once_cell",
  "similar",
  "tempfile",
@@ -3591,11 +3577,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3762,13 +3749,11 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "bitflags 2.13.1",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -4261,7 +4246,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4383,7 +4368,7 @@ dependencies = [
  "nix 0.29.0",
  "ntapi",
  "procfs",
- "sysinfo",
+ "sysinfo 0.33.1",
  "web-time",
  "windows 0.56.0",
 ]
@@ -4760,6 +4745,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4827,6 +4822,15 @@ checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4979,7 +4983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6304,7 +6308,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6604,6 +6608,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7012,6 +7027,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7120,7 +7149,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7757,14 +7786,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7899,6 +7929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7909,15 +7948,18 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7928,22 +7970,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7951,9 +7990,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7964,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -8046,9 +8085,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8170,11 +8209,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -8201,7 +8242,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8834,7 +8875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8903,7 +8944,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ percent-encoding = "2.2.0"
 portable-pty = "0.9.0"
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.25.0"
-rand = "0.9.0"
+rand = "0.10.2"
 rayon = "1.8.0"
 regex = "1.7.0"
 reqwest = { version = "0.12.14", default-features = false, features = [
@@ -120,12 +120,12 @@ shell-color = "1.0.0"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
 shlex = "2.0.1"
 similar = "2.7.0"
 spinners = "4.1.0"
 strum = { version = "0.28.0", features = ["derive"] }
-sysinfo = "0.33.1"
+sysinfo = "0.36.1"
 thiserror = "2.0.12"
 tempfile = "3.18.0"
 time = { version = "0.3.39", features = [
@@ -147,11 +147,11 @@ tracing-subscriber = { version = "0.3.19", features = [
     "time",
 ] }
 unicode-width = "0.2.0"
-url = "2.5.4"
+url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 walkdir = "2.5.0"
 which = "8.0.5"
-whoami = "1.6.0"
+whoami = "2.1.0"
 winnow = "0.6.2"
 
 # Keep these minor synced with reqwest

--- a/crates/ec_cli/Cargo.toml
+++ b/crates/ec_cli/Cargo.toml
@@ -35,7 +35,7 @@ color-print = "0.3.5"
 convert_case.workspace = true
 crossterm.workspace = true
 ctrlc = "3.4.6"
-dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
+dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }
 eyre.workspace = true
 fig_diagnostic.workspace = true
 fig_install.workspace = true

--- a/crates/ec_cli/src/cli/uninstall.rs
+++ b/crates/ec_cli/src/cli/uninstall.rs
@@ -16,7 +16,7 @@ pub async fn uninstall_command(no_confirm: bool) -> Result<ExitCode> {
         );
         let should_continue = dialoguer::Select::with_theme(&dialoguer_theme())
             .with_prompt(format!("Are you sure want to continue uninstalling {PRODUCT_NAME}?"))
-            .items(&["Yes", "No"])
+            .items(["Yes", "No"])
             .default(0)
             .interact_opt()?;
 

--- a/crates/ec_cli/src/util/mod.rs
+++ b/crates/ec_cli/src/util/mod.rs
@@ -241,8 +241,11 @@ pub fn choose(prompt: impl Display, options: &[impl ToString]) -> Result<Option<
         return Ok(Some(0));
     }
 
+    // dialoguer 0.12 requires the items to be `Display`, which `&impl ToString` is not.
+    let items: Vec<String> = options.iter().map(ToString::to_string).collect();
+
     match Select::with_theme(&dialoguer_theme())
-        .items(options)
+        .items(&items)
         .default(0)
         .with_prompt(prompt.to_string())
         .interact_opt()

--- a/crates/fig_desktop_api/src/init_script.rs
+++ b/crates/fig_desktop_api/src/init_script.rs
@@ -92,7 +92,7 @@ impl Constants {
             fig_data_dir: directories::fig_data_dir_utf8().ok(),
             backups_dir: directories::backups_dir_utf8().ok(),
             logs_dir: directories::logs_dir_utf8().ok(),
-            user: whoami::username(),
+            user: whoami::username().unwrap_or_default(),
             default_path: var("PATH").ok(),
             themes_folder,
             themes,

--- a/crates/fig_diagnostic/src/lib.rs
+++ b/crates/fig_diagnostic/src/lib.rs
@@ -26,6 +26,12 @@ fn is_false(value: &bool) -> bool {
     !value
 }
 
+/// `/<username>` for scrubbing the current user out of paths, or `None` if the username can't be
+/// determined — in which case we leave the path alone rather than replace something else.
+fn username_path_prefix() -> Option<String> {
+    whoami::username().ok().map(|username| format!("/{username}"))
+}
+
 #[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BuildDetails {
@@ -88,7 +94,7 @@ impl SystemInfo {
         let mut hardware_info = SystemInfo {
             os: os_version(),
             chip: None,
-            total_cores: system.physical_core_count(),
+            total_cores: sysinfo::System::physical_core_count(),
             memory: Some(format!("{:0.2} GB", system.total_memory() as f32 / 2.0_f32.powi(30))),
         };
 
@@ -108,6 +114,7 @@ pub struct EnvVarDiagnostic {
 
 impl EnvVarDiagnostic {
     fn new() -> EnvVarDiagnostic {
+        let username = username_path_prefix();
         let env_vars = std::env::vars()
             .filter(|(key, _)| {
                 let fig_var = fig_util::env_var::ALL.contains(&key.as_str());
@@ -135,8 +142,10 @@ impl EnvVarDiagnostic {
             })
             .map(|(key, value)| {
                 // sanitize username from values
-                let username = format!("/{}", whoami::username());
-                (key, value.replace(&username, "/USER"))
+                match &username {
+                    Some(username) => (key, value.replace(username, "/USER")),
+                    None => (key, value),
+                }
             })
             .collect();
 
@@ -171,25 +180,18 @@ impl CurrentEnvironment {
         use fig_util::process_info::{Pid, PidExt};
         let ctx = Context::new();
 
-        let username = format!("/{}", whoami::username());
+        let username = username_path_prefix();
+        let scrub = |path: std::path::PathBuf| match &username {
+            Some(username) => path.to_string_lossy().replace(username, "/USER"),
+            None => path.to_string_lossy().into_owned(),
+        };
 
-        let shell_path = Pid::current()
-            .parent()
-            .and_then(|pid| pid.exe())
-            .map(|p| p.to_string_lossy().replace(&username, "/USER"));
+        let shell_path = Pid::current().parent().and_then(|pid| pid.exe()).map(scrub);
         let shell_version = Shell::current_shell_version().await.map(|(_, v)| v).ok();
 
-        let cwd = ctx
-            .env()
-            .current_dir()
-            .ok()
-            .map(|path| path.to_string_lossy().replace(&username, "/USER"));
+        let cwd = ctx.env().current_dir().ok().map(scrub);
 
-        let cli_path = ctx
-            .env()
-            .current_dir()
-            .ok()
-            .map(|path| path.to_string_lossy().replace(&username, "/USER"));
+        let cli_path = ctx.env().current_dir().ok().map(scrub);
 
         let os = ctx.platform().os();
         let terminal = Terminal::parent_terminal(&ctx);

--- a/crates/fig_proto/src/mux.rs
+++ b/crates/fig_proto/src/mux.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 
 use flate2::Compression;
 use prost::Message;
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt};
 use thiserror::Error;
 
 pub use crate::proto::mux::*;

--- a/crates/fig_util/Cargo.toml
+++ b/crates/fig_util/Cargo.toml
@@ -27,7 +27,7 @@ rand.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha2 = "0.10.9"
+sha2.workspace = true
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror.workspace = true
 time.workspace = true

--- a/crates/fig_util/src/directories.rs
+++ b/crates/fig_util/src/directories.rs
@@ -631,8 +631,9 @@ mod tests {
             path = path.replace(home, "$HOME");
         }
 
-        let user = whoami::username();
-        path = path.replace(&user, "$USER");
+        if let Ok(user) = whoami::username() {
+            path = path.replace(&user, "$USER");
+        }
 
         if let Ok(tmpdir) = std::env::var("TMPDIR") {
             let tmpdir = tmpdir.strip_suffix('/').unwrap_or(&tmpdir);

--- a/crates/fig_util/src/lib.rs
+++ b/crates/fig_util/src/lib.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 pub use consts::*;
 pub use open::{open_url, open_url_async};
 pub use process_info::get_parent_process_exe;
-use rand::Rng;
+use rand::RngExt;
 pub use shell::Shell;
 pub use terminal::Terminal;
 use thiserror::Error;

--- a/crates/fig_util/src/system_info/mod.rs
+++ b/crates/fig_util/src/system_info/mod.rs
@@ -340,7 +340,7 @@ pub fn get_system_id() -> Option<&'static str> {
             let hwid = raw_system_id().ok()?;
             let mut hasher = Sha256::new();
             hasher.update(hwid);
-            Some(format!("{:x}", hasher.finalize()))
+            Some(hex::encode(hasher.finalize()))
         })
         .as_deref()
 }

--- a/packages/autocomplete-app/package.json
+++ b/packages/autocomplete-app/package.json
@@ -35,7 +35,7 @@
     "react-window": "^1.8.11",
     "react": "^19.2.8",
     "tailwind-merge": "^3.2.0",
-    "use-resize-observer": "^9.1.0",
+    "use-resize-observer": "^10.0.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/packages/autocomplete-app/src/hooks/helpers.ts
+++ b/packages/autocomplete-app/src/hooks/helpers.ts
@@ -1,21 +1,36 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 
-import useResizeObserver from "use-resize-observer";
+import { useResizeObserver } from "use-resize-observer";
 
 type Dimensions = {
   height?: number;
   width?: number;
 };
 
+// Callers only care about the size, not the `ResizeObserverEntry` that
+// use-resize-observer hands to its own `onResize`.
+type DynamicResizeObserverOpts<T extends Element> = Omit<
+  NonNullable<Parameters<typeof useResizeObserver<T>>[0]>,
+  "onResize"
+> & {
+  onResize?: (size: Dimensions) => void;
+};
+
 // Like resizeObserver but re-calls onResize callback when onResize changes.
-export const useDynamicResizeObserver: typeof useResizeObserver = (opts) => {
+export const useDynamicResizeObserver = <T extends Element>(
+  opts?: DynamicResizeObserverOpts<T>,
+) => {
   const { onResize, ...otherOpts } = opts || {};
   const [{ height, width }, setDimensions] = useState<Dimensions>({
     height: 0,
     width: 0,
   });
 
-  const { ref } = useResizeObserver({ ...otherOpts, onResize: setDimensions });
+  const { ref } = useResizeObserver<T>({
+    ...otherOpts,
+    onResize: ({ height: nextHeight, width: nextWidth }) =>
+      setDimensions({ height: nextHeight, width: nextWidth }),
+  });
 
   useEffect(() => {
     if (onResize) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: ^3.2.0
         version: 3.6.0
       use-resize-observer:
-        specifier: ^9.1.0
-        version: 9.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^10.0.0
+        version: 10.0.0(react@19.2.8)
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -933,9 +933,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@juggle/resize-observer@3.4.0':
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2621,11 +2618,10 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  use-resize-observer@9.1.0:
-    resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
+  use-resize-observer@10.0.0:
+    resolution: {integrity: sha512-bR6D9uOoNB51isaK3yFs12+0Ue81jwHawsvdIyOIq5o+4ekmHn4U207IlBf3zc0fLHckhXLQtFl8moEOKcGGAQ==}
     peerDependencies:
-      react: 16.8.0 - 18
-      react-dom: 16.8.0 - 18
+      react: '>=18.2'
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -3247,8 +3243,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
-
-  '@juggle/resize-observer@3.4.0': {}
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -3984,7 +3978,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -4984,11 +4978,9 @@ snapshots:
       requires-port: 1.0.0
     optional: true
 
-  use-resize-observer@9.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  use-resize-observer@10.0.0(react@19.2.8):
     dependencies:
-      '@juggle/resize-observer': 3.4.0
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:


### PR DESCRIPTION
These bumps all had open Dependabot PRs that failed CI because the new major versions moved APIs we call. Doing them together keeps one lockfile churn instead of seven.

- rand 0.9 -> 0.10: the old `Rng` trait split into `Rng` (formerly `RngCore`) and `RngExt`; `fill`/`random_range` now live on `RngExt`.
- sha2 0.10 -> 0.11: digest output no longer implements `LowerHex`, so hex-encode it explicitly. Point fig_util at the workspace entry while we're here, since it had drifted to its own version.
- sysinfo 0.33 -> 0.36: `physical_core_count` is an associated function.
- whoami 1.6 -> 2.1: `username()` returns a `Result`. Where we use it to scrub the current user out of diagnostics paths, skip the substitution rather than replace on a placeholder.
- url 2.5.4 -> 2.5.8: `Serialize` for `Url` is behind the `serde` feature now, which we relied on implicitly.
- dialoguer 0.11 -> 0.12: `Select::items` requires `Display`, which `&impl ToString` does not satisfy — collect the labels first.
- use-resize-observer 9 -> 10: named export instead of default, and `onResize` now receives the `ResizeObserverEntry` alongside the size. Our wrapper keeps its size-only contract so callers are unaffected.

Closes #10, #19, #50, #51, #86, #99, #143