### PR TITLE
fix: migrate native dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ version = "0.1.3"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -792,7 +792,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
@@ -1478,7 +1478,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1516,7 +1516,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
@@ -1631,7 +1631,7 @@ dependencies = [
  "insta",
  "macos-utils",
  "mimalloc",
- "nix 0.29.0",
+ "nix 0.31.3",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -1735,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1874,7 +1874,7 @@ dependencies = [
  "clap",
  "cocoa",
  "core-foundation 0.10.1",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
  "dashmap",
  "dispatch",
  "fig_desktop_api",
@@ -1900,7 +1900,7 @@ dependencies = [
  "mime",
  "moka",
  "muda",
- "nix 0.29.0",
+ "nix 0.31.3",
  "notify",
  "objc",
  "objc2 0.5.2",
@@ -2071,7 +2071,7 @@ dependencies = [
  "indoc",
  "insta",
  "macos-utils",
- "nix 0.29.0",
+ "nix 0.31.3",
  "objc",
  "owo-colors",
  "plist",
@@ -2095,7 +2095,7 @@ dependencies = [
  "fig_proto",
  "fig_util",
  "flate2",
- "nix 0.29.0",
+ "nix 0.31.3",
  "pin-project-lite",
  "rand 0.10.2",
  "tempfile",
@@ -2127,7 +2127,7 @@ version = "2.2.2"
 dependencies = [
  "cfg-if",
  "dirs 5.0.1",
- "nix 0.29.0",
+ "nix 0.31.3",
  "serde",
  "sysinfo 0.36.1",
  "tempfile",
@@ -2143,7 +2143,7 @@ dependencies = [
  "fig_util",
  "flate2",
  "hex",
- "nix 0.29.0",
+ "nix 0.31.3",
  "prost",
  "prost-build",
  "prost-reflect",
@@ -2254,7 +2254,7 @@ dependencies = [
  "insta",
  "libc",
  "macos-utils",
- "nix 0.29.0",
+ "nix 0.31.3",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2305,7 +2305,7 @@ dependencies = [
  "lazy_static",
  "memmem",
  "mimalloc",
- "nix 0.29.0",
+ "nix 0.31.3",
  "num-traits",
  "parking_lot",
  "pin-project",
@@ -3327,7 +3327,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
  "qoi",
  "ravif",
  "rayon",
@@ -3643,30 +3643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
-name = "libappindicator"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
-dependencies = [
- "glib",
- "gtk",
- "gtk-sys",
- "libappindicator-sys",
- "log",
-]
-
-[[package]]
-name = "libappindicator-sys"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
-dependencies = [
- "gtk-sys",
- "libloading 0.7.4",
- "once_cell",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,16 +3665,6 @@ checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
 ]
 
 [[package]]
@@ -3864,12 +3830,12 @@ dependencies = [
  "block2 0.5.1",
  "cocoa",
  "core-foundation 0.10.1",
- "core-graphics 0.24.0",
+ "core-graphics 0.25.0",
  "dashmap",
  "flume",
  "fnv",
  "libc",
- "nix 0.29.0",
+ "nix 0.31.3",
  "objc",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -4056,21 +4022,21 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.15.3"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae9c00e61cc0579bcac625e8ad22104c60548a025bfc972dc83868a28e1484"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
- "gtk",
  "keyboard-types 0.7.0",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
- "thiserror 1.0.69",
- "windows-sys 0.59.0",
+ "png",
+ "thiserror 2.0.20",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4236,7 +4202,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4973,7 +4939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5273,19 +5239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -5761,7 +5714,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6295,7 +6248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7136,7 +7089,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7633,13 +7586,12 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.19.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadd75f5002e2513eaa19b2365f533090cc3e93abd38788452d9ea85cff7b48a"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
- "libappindicator",
  "muda",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
@@ -7647,9 +7599,9 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png",
  "thiserror 2.0.20",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8234,7 +8186,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8867,7 +8819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ color-print = "0.3.5"
 convert_case = "0.11.0"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"
-core-graphics = "0.24.0"
+core-graphics = "0.25.0"
 crossterm = { version = "0.29.0", features = ["event-stream", "events"] }
 dashmap = "6.0.1"
 dirs = "5.0.0"
@@ -77,7 +77,7 @@ indoc = "2.0.6"
 insta = "1.43.1"
 libc = "0.2.172"
 mimalloc = "0.1.46"
-nix = { version = "0.29.0", features = [
+nix = { version = "0.31.3", features = [
     "feature",
     "fs",
     "ioctl",

--- a/crates/fig_desktop/Cargo.toml
+++ b/crates/fig_desktop/Cargo.toml
@@ -65,7 +65,7 @@ infer = "0.22.0"
 keyboard-types = "0.8.0"
 mime = "0.3.17"
 moka = { version = "0.12.1", features = ["future"] }
-muda = { version = "0.15.3", default-features = false }
+muda = { version = "0.19.3", default-features = false }
 notify = "8.0.0"
 parking_lot = { workspace = true, features = ["serde"] }
 paste = "1.0.11"
@@ -84,7 +84,7 @@ tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tray-icon = { version = "0.19.2", default-features = false }
+tray-icon = { version = "0.24.2", default-features = false }
 url.workspace = true
 uuid.workspace = true
 which.workspace = true

--- a/crates/figterm/src/pty/unix.rs
+++ b/crates/figterm/src/pty/unix.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 
@@ -33,10 +33,10 @@ struct UnixAsyncMasterPty {
 }
 
 /// Helper function to set the close-on-exec flag for a raw descriptor
-fn cloexec(fd: RawFd) -> Result<()> {
-    let flags = fcntl(fd, FcntlArg::F_GETFD)?;
+fn cloexec(fd: impl AsFd) -> Result<()> {
+    let flags = fcntl(&fd, FcntlArg::F_GETFD)?;
     fcntl(
-        fd,
+        &fd,
         FcntlArg::F_SETFD(FdFlag::from_bits_truncate(flags) | FdFlag::FD_CLOEXEC),
     )?;
     Ok(())
@@ -76,23 +76,23 @@ pub fn open_pty(pty_size: &PtySize) -> Result<PtyPair> {
         ws_xpixel: pty_size.pixel_width,
         ws_ypixel: pty_size.pixel_height,
     };
-    unsafe { ioctl_tiocswinsz(slave_pty, &winsize) }?;
+    unsafe { ioctl_tiocswinsz(slave_pty.as_raw_fd(), &winsize) }?;
 
     #[cfg(target_os = "freebsd")]
-    set_nonblocking(master_pty.as_raw_fd()).context("Failed to set nonblocking")?;
+    set_nonblocking(&master_pty).context("Failed to set nonblocking")?;
 
     let master = UnixMasterPty { fd: master_pty };
     let slave = UnixSlavePty {
         name: pty_name,
-        fd: unsafe { FileDescriptor::from_raw_fd(slave_pty) },
+        fd: FileDescriptor::new(slave_pty),
     };
 
     // Ensure that these descriptors will get closed when we execute
     // the child process. This is done after constructing the Pty
     // instances so that we ensure that the Ptys get drop()'d if
     // the cloexec() functions fail (unlikely!).
-    cloexec(master.fd.as_raw_fd())?;
-    cloexec(slave.fd.as_raw_fd())?;
+    cloexec(&master.fd)?;
+    cloexec(&slave.fd)?;
 
     Ok(PtyPair {
         master: Box::new(master),
@@ -230,16 +230,14 @@ impl AsRawFd for UnixMasterPty {
 
 /// Set `fd` into non-blocking mode using `O_NONBLOCKING`
 #[cfg(target_os = "freebsd")]
-fn set_nonblocking(fd: RawFd) -> Result<()> {
+fn set_nonblocking(fd: impl AsFd) -> Result<()> {
     use nix::fcntl;
 
-    let old_oflag_c_int =
-        fcntl::fcntl(fd, FcntlArg::F_GETFL).with_context(|| format!("Failed to get flags for fd {fd:?}"))?;
+    let old_oflag_c_int = fcntl::fcntl(&fd, FcntlArg::F_GETFL).context("Failed to get flags for fd")?;
 
     let old_oflag = OFlag::from_bits_truncate(old_oflag_c_int);
 
-    fcntl::fcntl(fd, FcntlArg::F_SETFL(old_oflag | OFlag::O_NONBLOCK))
-        .with_context(|| format!("Failed to set O_NONBLOCK for fd {fd:?}"))?;
+    fcntl::fcntl(&fd, FcntlArg::F_SETFL(old_oflag | OFlag::O_NONBLOCK)).context("Failed to set O_NONBLOCK for fd")?;
 
     Ok(())
 }

--- a/crates/figterm/src/term/istty.rs
+++ b/crates/figterm/src/term/istty.rs
@@ -4,6 +4,8 @@
 //! return true if the item represents a terminal.
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::io::BorrowedFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 
@@ -24,7 +26,9 @@ pub trait IsTty {
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
-        nix::unistd::isatty(fd).unwrap_or_default()
+        // SAFETY: `fd` stays valid for the lifetime of `self` and the borrow
+        // does not escape this call.
+        nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(fd) }).unwrap_or_default()
     }
 }
 

--- a/crates/macos-utils/src/window_server/ui_element.rs
+++ b/crates/macos-utils/src/window_server/ui_element.rs
@@ -18,7 +18,11 @@ use core_foundation::dictionary::CFDictionary;
 use core_foundation::number::CFNumber;
 use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::display::{self, CGRect};
-use core_graphics::window::{CGWindowID, kCGWindowBounds, kCGWindowLayer, kCGWindowNumber, kCGWindowOwnerPID};
+use core_graphics::window::{
+    CGWindowID, kCGNullWindowID, kCGWindowBounds, kCGWindowLayer, kCGWindowListExcludeDesktopElements,
+    kCGWindowListOptionAll, kCGWindowListOptionIncludingWindow, kCGWindowListOptionOnScreenOnly, kCGWindowNumber,
+    kCGWindowOwnerPID,
+};
 use tracing::warn;
 
 use crate::util::{NSArrayRef, NSStringRef};
@@ -266,14 +270,14 @@ impl UIElement {
             let window_id = self.get_window_id().ok()?;
             let windows = if all_windows {
                 CFArray::<CFDictionary>::wrap_under_create_rule(display::CGWindowListCopyWindowInfo(
-                    display::kCGWindowListOptionAll,
-                    display::kCGNullWindowID,
+                    kCGWindowListOptionAll,
+                    kCGNullWindowID,
                 ))
             } else {
                 CFArray::<CFDictionary>::wrap_under_create_rule(display::CGWindowListCopyWindowInfo(
-                    display::kCGWindowListOptionOnScreenOnly
-                        | display::kCGWindowListExcludeDesktopElements
-                        | display::kCGWindowListOptionIncludingWindow,
+                    kCGWindowListOptionOnScreenOnly
+                        | kCGWindowListExcludeDesktopElements
+                        | kCGWindowListOptionIncludingWindow,
                     window_id,
                 ))
             };


### PR DESCRIPTION
## What changed

- upgrade `tray-icon` to 0.24.2 together with its matching `muda` 0.19.3 API generation
- upgrade `core-graphics` to 0.25.0 and use the relocated window-list constants
- upgrade `nix` to 0.31.3 and migrate PTY/TTY handling to `AsFd`, `BorrowedFd`, and `OwnedFd`

## Why

The individual Dependabot PRs #8, #15, #117, and #151 failed because these dependency updates require coordinated API and lockfile changes. In particular, `tray-icon` and `muda` must move together to avoid two incompatible `muda::Menu` types.

## Validation

- `cargo check --locked -p figterm -p fig_desktop -p macos-utils`
- `cargo clippy --locked --workspace --color always -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

Supersedes #8, #15, #117, and #151.