### PR TITLE
fix: migrate Node.js types to v26

### DIFF
--- a/packages/api-bindings/package.json
+++ b/packages/api-bindings/package.json
@@ -29,7 +29,7 @@
     "@easy-complete/eslint-config": "workspace:^",
     "@easy-complete/tsconfig": "workspace:^",
     "@tsconfig/recommended": "^1.0.13",
-    "@types/node": "^22.15.20",
+    "@types/node": "^26.2.0",
     "@typescript/analyze-trace": "^0.11.1",
     "eslint": "^10.8.1",
     "lint-staged": "^17.3.0",

--- a/packages/autocomplete-app/package.json
+++ b/packages/autocomplete-app/package.json
@@ -43,7 +43,7 @@
     "@easy-complete/types": "workspace:^",
     "@easy-complete/fuzzysort": "workspace:^",
     "@easy-complete/shared": "workspace:^",
-    "@types/node": "^22.15.20",
+    "@types/node": "^26.2.0",
     "@types/react-dom": "^19.2.4",
     "@types/react-window": "^1.8.8",
     "@types/react": "^19.2.18",

--- a/packages/autocomplete-app/src/state/insertion.ts
+++ b/packages/autocomplete-app/src/state/insertion.ts
@@ -138,7 +138,7 @@ const insertString = (
     insertionLengthFull: `${inserted.insertedCharsFull}`,
     app: fig.constants?.version || "",
     terminal: state.figState.shellContext?.terminal ?? null,
-    shell: state.figState.shellContext?.shellPath?.split("/")?.at(-1) ?? null,
+    shell: state.figState.shellContext?.shellPath?.split("/").pop() ?? null,
   });
 
   logger.info("Inserted string, updating visibility");

--- a/packages/dashboard-app/package.json
+++ b/packages/dashboard-app/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@easy-complete/eslint-config": "workspace:^",
     "@easy-complete/types": "workspace:^",
-    "@types/node": "^22.15.20",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 2.10.9
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/api-bindings:
     dependencies:
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.0.13
         version: 1.0.13
       '@types/node':
-        specifier: ^22.15.20
-        version: 22.15.20
+        specifier: ^26.2.0
+        version: 26.2.0
       '@typescript/analyze-trace':
         specifier: ^0.11.1
         version: 0.11.1
@@ -197,8 +197,8 @@ importers:
         specifier: workspace:^
         version: link:../types
       '@types/node':
-        specifier: ^22.15.20
-        version: 22.15.20
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -210,7 +210,7 @@ importers:
         version: 1.8.8
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
       '@withfig/autocomplete-types':
         specifier: ^1.31.0
         version: 1.31.0
@@ -228,16 +228,16 @@ importers:
         version: 3.9.6
       tailwindcss:
         specifier: ^3.4.19
-        version: 3.4.19(ts-node@10.9.2(@types/node@22.15.20)(typescript@5.8.3))
+        version: 3.4.19(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.8.3))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vite:
         specifier: ^8.2.1
-        version: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/autocomplete-parser:
     dependencies:
@@ -295,7 +295,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/dashboard-app:
     dependencies:
@@ -328,8 +328,8 @@ importers:
         specifier: workspace:^
         version: link:../types
       '@types/node':
-        specifier: ^22.15.20
-        version: 22.15.20
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -338,7 +338,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.5.4
         version: 10.5.4(postcss@8.5.26)
@@ -353,13 +353,13 @@ importers:
         version: 3.9.6
       tailwindcss:
         specifier: ^3.4.19
-        version: 3.4.19(ts-node@10.9.2(@types/node@22.15.20)(typescript@6.0.3))
+        version: 3.4.19(ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.2.1
-        version: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -428,7 +428,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/shell-parser:
     dependencies:
@@ -456,7 +456,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/tsconfig:
     dependencies:
@@ -1106,8 +1106,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@22.15.20':
-    resolution: {integrity: sha512-A6BohGFRGHAscJsTslDCA9JG7qSJr/DWUvrvY8yi9IgnGtMxCyat7vvQ//MFa0DnLsyuS3wYTpLdw4Hf+Q5JXw==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -2587,8 +2587,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -3341,9 +3341,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@22.15.20':
+  '@types/node@26.2.0':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 8.3.0
 
   '@types/prop-types@15.7.15': {}
 
@@ -3475,10 +3475,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -3492,7 +3492,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3503,13 +3503,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3538,7 +3538,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -4481,21 +4481,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.26
 
-  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.15.20)(typescript@5.8.3)):
+  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       postcss: 8.5.26
-      ts-node: 10.9.2(@types/node@22.15.20)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@26.2.0)(typescript@5.8.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.15.20)(typescript@6.0.3)):
+  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       postcss: 8.5.26
-      ts-node: 10.9.2(@types/node@22.15.20)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@26.2.0)(typescript@6.0.3)
 
   postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
@@ -4720,7 +4720,7 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.15.20)(typescript@5.8.3)):
+  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.8.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4739,7 +4739,7 @@ snapshots:
       postcss: 8.5.26
       postcss-import: 15.1.0(postcss@8.5.26)
       postcss-js: 4.0.1(postcss@8.5.26)
-      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.15.20)(typescript@5.8.3))
+      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.8.3))
       postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -4747,7 +4747,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.15.20)(typescript@6.0.3)):
+  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4766,7 +4766,7 @@ snapshots:
       postcss: 8.5.26
       postcss-import: 15.1.0(postcss@8.5.26)
       postcss-js: 4.0.1(postcss@8.5.26)
-      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.15.20)(typescript@6.0.3))
+      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3))
       postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -4843,14 +4843,14 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@types/node@22.15.20)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@26.2.0)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.20
+      '@types/node': 26.2.0
       acorn: 8.18.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -4862,14 +4862,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.15.20)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@26.2.0)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.20
+      '@types/node': 26.2.0
       acorn: 8.18.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -4923,7 +4923,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@8.3.0: {}
 
   universalify@0.2.0:
     optional: true
@@ -4964,7 +4964,7 @@ snapshots:
   v8-compile-cache-lib@3.0.1:
     optional: true
 
-  vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3):
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -4972,7 +4972,7 @@ snapshots:
       rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.15.20
+      '@types/node': 26.2.0
       esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 1.21.7
@@ -4980,10 +4980,10 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.8.3
 
-  vitest@4.1.10(@types/node@22.15.20)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@24.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -5000,10 +5000,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.20
+      '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
       jsdom: 24.1.0


### PR DESCRIPTION
## What changed

- upgrade `@types/node` from 22.15.20 to 26.2.0 in the three workspace packages that declare it
- replace `Array.prototype.at(-1)` with ES2020-compatible `pop()` for shell-name extraction

## Why

Dependabot PR #174 failed because the autocomplete app targets ES2020, while the updated Node.js type environment no longer made `Array.prototype.at` available under that lib target. Keeping the ES2020 runtime contract and using `pop()` is narrower than raising the browser target.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint` (passes with 6 pre-existing hook warnings)
- `pnpm test:ci` (179 passed, 2 files skipped)
- `git diff --check`

Supersedes #174.