### PR TITLE
chore: update Vite React plugin to 6.0.5

### DIFF
--- a/packages/autocomplete-app/package.json
+++ b/packages/autocomplete-app/package.json
@@ -47,7 +47,7 @@
     "@types/react-dom": "^19.2.4",
     "@types/react-window": "^1.8.8",
     "@types/react": "^19.2.18",
-    "@vitejs/plugin-react": "^6.0.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "@withfig/autocomplete-types": "^1.31.0",
     "autoprefixer": "^10.5.4",
     "eslint": "^10.8.1",

--- a/packages/dashboard-app/package.json
+++ b/packages/dashboard-app/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.15.20",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
-    "@vitejs/plugin-react": "^6.0.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.5.4",
     "eslint": "^10.8.1",
     "postcss": "^8.5.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^1.8.8
         version: 1.8.8
       '@vitejs/plugin-react':
-        specifier: ^6.0.4
-        version: 6.0.4(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        specifier: ^6.0.5
+        version: 6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
       '@withfig/autocomplete-types':
         specifier: ^1.31.0
         version: 1.31.0
@@ -337,8 +337,8 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
-        specifier: ^6.0.4
-        version: 6.0.4(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
+        specifier: ^6.0.5
+        version: 6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.5.4
         version: 10.5.4(postcss@8.5.26)
@@ -1197,8 +1197,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  '@vitejs/plugin-react@6.0.4':
-    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -3475,7 +3475,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.4(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.1(@types/node@22.15.20)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.39.0)(tsx@4.23.11)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- update `@vitejs/plugin-react` to 6.0.5 in both Vite React apps
- regenerate the root lockfile against Vite 8.2.1
- supersede conflicting Dependabot PR #142

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint` (passes with 6 pre-existing React hook warnings)
- `pnpm test:ci` (179 passed, 2 files skipped, 108 todo)
- `git diff --check`